### PR TITLE
Use Mozilla SSO for sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,29 @@
 
 This is the app behind the Mozilla Mentoring Program
 
+## Structure
+
 * [mentoring](./mentoring) - main Django project
   * [enrollment](mentoring/enrollment) - app handling participant enrollment
   * [participants](mentoring/participants) - app handling participant data
   * [pairs](mentoring/pairs) - app handling pairing
   * [frontend](mentoring/frontend) - app to render the frontend
 * [frontend](./frontend) - main React project
+
+## Authentication
+
+This app uses Mozilla's SSO for authentication.
+It requires an Auth0 client be created, with
+ * Algorithm `RS256`
+ * Redirect URI of `https://<hostname>/oidc/callback/` (note the trailing `/`)
+ * At least the Mozilla AD connection enabled ("Allowing Mozilla LDAP with MFA")
+
+Set `OIDC_RP_CLIENT_ID` `OIDC_RP_CLIENT_SECRET` using the resulting credentials.
+
+The UI automatically redirects to the sign-in URL.
+There is no way to interact with the UI without first signing in.
+Signing in creates a Django user and remaining authentication is performed using a Django session.
+
+Members of groups listed in `STAFF_GROUPS` have "staff" access to the app.
+This includes access to the REST API (`/api`) and the Django administration panel (`/admin/`).
+Those who are not staff have access only to the enrollment form.

--- a/frontend/.eslintrc.yml
+++ b/frontend/.eslintrc.yml
@@ -17,4 +17,4 @@ parserOptions:
   sourceType: module
 rules: {}
 globals:
-  csrftoken: readonly # this global is set by Django in the wrapper HTML
+  MENTORING_SETTINGS: readonly # this global is set by Django in the wrapper HTML

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -72,6 +72,13 @@ export default function App() {
             <Typography variant="h6" style={{ flexGrow: '1' }}>
               Mozilla Mentoring Program
             </Typography>
+            <a href={MENTORING_SETTINGS.loginUrl}>
+              <Tooltip placement="bottom" title="Login (temporary)">
+                <IconButton>
+                  <CogOutlineIcon className={classes.appIcon} />
+                </IconButton>
+              </Tooltip>
+            </a>
             <a href="/admin/">
               <Tooltip placement="bottom" title="Admin Panel">
                 <IconButton>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -77,9 +77,6 @@ export default function App() {
                 {MENTORING_SETTINGS.user.first_name} {MENTORING_SETTINGS.user.last_name}
               </Typography>
             )}
-            <a href={MENTORING_SETTINGS.loginUrl}>
-              Login
-            </a>
             {MENTORING_SETTINGS.user.is_staff && (
               <Fragment>
                 <a href="/admin/">

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,12 +1,8 @@
 import React, { Fragment } from "react";
 import Helmet from 'react-helmet';
 import AppBar from '@material-ui/core/AppBar';
-import IconButton from '@material-ui/core/IconButton';
 import Toolbar from '@material-ui/core/Toolbar';
-import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
-import CogOutlineIcon from 'mdi-react/CogOutlineIcon';
-import CodeJsonIcon from 'mdi-react/CodeJsonIcon';
 import Home from './views/Home';
 import Pairing from './views/Pairing';
 import { ThemeProvider, createMuiTheme, makeStyles } from '@material-ui/core/styles';
@@ -72,29 +68,15 @@ export default function App() {
             <Typography variant="h6" style={{ flexGrow: '1' }}>
               Mozilla Mentoring Program
             </Typography>
-            {MENTORING_SETTINGS.user.username && (
-              <Typography>
-                {MENTORING_SETTINGS.user.first_name} {MENTORING_SETTINGS.user.last_name}
-              </Typography>
-            )}
-            {MENTORING_SETTINGS.user.is_staff && (
-              <Fragment>
-                <a href="/admin/">
-                  <Tooltip placement="bottom" title="Admin Panel">
-                    <IconButton>
-                      <CogOutlineIcon className={classes.appIcon} />
-                    </IconButton>
-                  </Tooltip>
-                </a>
-                <a href="/api/">
-                  <Tooltip placement="bottom" title="REST API">
-                    <IconButton>
-                      <CodeJsonIcon className={classes.appIcon} />
-                    </IconButton>
-                  </Tooltip>
-                </a>
-              </Fragment>
-            )}
+            <Typography>
+              {MENTORING_SETTINGS.user.username ? (
+                <Fragment>
+                  {MENTORING_SETTINGS.user.first_name} {MENTORING_SETTINGS.user.last_name}
+                </Fragment>
+              ) : (
+                "(not signed in)"
+              )}
+            </Typography>
           </Toolbar>
         </AppBar>
         <Switch>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Fragment } from "react";
 import Helmet from 'react-helmet';
 import AppBar from '@material-ui/core/AppBar';
 import IconButton from '@material-ui/core/IconButton';
@@ -72,27 +72,32 @@ export default function App() {
             <Typography variant="h6" style={{ flexGrow: '1' }}>
               Mozilla Mentoring Program
             </Typography>
+            {MENTORING_SETTINGS.user.username && (
+              <Typography>
+                {MENTORING_SETTINGS.user.first_name} {MENTORING_SETTINGS.user.last_name}
+              </Typography>
+            )}
             <a href={MENTORING_SETTINGS.loginUrl}>
-              <Tooltip placement="bottom" title="Login (temporary)">
-                <IconButton>
-                  <CogOutlineIcon className={classes.appIcon} />
-                </IconButton>
-              </Tooltip>
+              Login
             </a>
-            <a href="/admin/">
-              <Tooltip placement="bottom" title="Admin Panel">
-                <IconButton>
-                  <CogOutlineIcon className={classes.appIcon} />
-                </IconButton>
-              </Tooltip>
-            </a>
-            <a href="/api/">
-              <Tooltip placement="bottom" title="REST API">
-                <IconButton>
-                  <CodeJsonIcon className={classes.appIcon} />
-                </IconButton>
-              </Tooltip>
-            </a>
+            {MENTORING_SETTINGS.user.is_staff && (
+              <Fragment>
+                <a href="/admin/">
+                  <Tooltip placement="bottom" title="Admin Panel">
+                    <IconButton>
+                      <CogOutlineIcon className={classes.appIcon} />
+                    </IconButton>
+                  </Tooltip>
+                </a>
+                <a href="/api/">
+                  <Tooltip placement="bottom" title="REST API">
+                    <IconButton>
+                      <CodeJsonIcon className={classes.appIcon} />
+                    </IconButton>
+                  </Tooltip>
+                </a>
+              </Fragment>
+            )}
           </Toolbar>
         </AppBar>
         <Switch>

--- a/frontend/src/data/pairing.js
+++ b/frontend/src/data/pairing.js
@@ -13,7 +13,6 @@ export function usePostPairing() {
   return useAxios({
     url: '/api/pairs',
     method: 'POST',
-    // this global is set by Django in the wrapper HTML
-    headers: { 'X-CSRFToken': csrftoken },
+    headers: { 'X-CSRFToken': MENTORING_SETTINGS.csrftoken },
   }, { manual: true });
 }

--- a/frontend/src/views/Home.js
+++ b/frontend/src/views/Home.js
@@ -2,13 +2,17 @@ import React, { Fragment } from "react";
 import { Link } from "react-router-dom";
 
 export default function Home() {
+  const staffMenu = (
+    <ul>
+      <li><Link to="/pairing">Pairing</Link></li>
+      <li><a href="/admin/">DB Administration Panel</a></li>
+      <li><a href="/api/">REST API Explorer</a></li>
+    </ul>
+  );
   return (
     <Fragment>
       <h1>Mozilla Mentorship Program</h1>
-      <ul>
-        <li><a href="/admin/">Administration</a></li>
-        <li><Link to="/pairing">Pairing</Link></li>
-      </ul>
+      {MENTORING_SETTINGS.user.is_staff && staffMenu}
     </Fragment>
   );
 }

--- a/frontend/test/helper.js
+++ b/frontend/test/helper.js
@@ -8,7 +8,9 @@ export const api = {
    */
   mock() {
     // this global is ordinarily set by Django in the wrapper HTML
-    global.csrftoken = 'abc'; // eslint-disable-line no-undef
+    global.MENTORING_SETTINGS = { // eslint-disable-line no-undef
+      csrftoken: 'abc',
+    };
     useAxios.mockImplementation(
       new AxiosHooksMock(
         [...arguments],

--- a/mentoring/auth.py
+++ b/mentoring/auth.py
@@ -1,0 +1,39 @@
+from django.conf import settings
+from mozilla_django_oidc.auth import OIDCAuthenticationBackend
+
+
+class MentoringAuthBackend(OIDCAuthenticationBackend):
+    """
+    Customization of the connection between OIDC and Django.
+
+    https://mozilla-django-oidc.readthedocs.io/en/stable/installation.html#additional-optional-configuration
+    """
+
+    def get_username(self, claims):
+        """
+        Use the OIDC `sub` claim as the username, as it is guaranteed to be unique and not change
+        """
+        return claims['sub']
+
+    def create_user(self, claims):
+        """
+        Set custom user properties based on OIDC claims
+        """
+        user = super(MentoringAuthBackend, self).create_user(claims)
+        return self.update_user(user, claims)
+
+    def update_user(self, user, claims):
+        """
+        Update first_name, last_name, and is_admin on a user, based
+        on oidc profile claims.
+        """
+        user.first_name = claims.get('given_name', '')
+        user.email = claims.get('email', '')
+        user.last_name = claims.get('family_name', '')
+
+        groups = claims.get("https://sso.mozilla.com/claim/groups", [])
+        user.is_staff = any(x in groups for x in settings.ALLOWED_ADMIN_GROUPS)
+
+        user.save()
+
+        return user

--- a/mentoring/auth.py
+++ b/mentoring/auth.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
+import urllib.parse
 
 
 class MentoringAuthBackend(OIDCAuthenticationBackend):
@@ -11,9 +12,12 @@ class MentoringAuthBackend(OIDCAuthenticationBackend):
 
     def get_username(self, claims):
         """
-        Use the OIDC `sub` claim as the username, as it is guaranteed to be unique and not change
+        Use the OIDC `sub` claim as the username, as it is guaranteed to be
+        unique and not change.  It is escaped using a format similar to
+        urlencoding, to the Django requirement "alphanumeric, _, @, +, . and -
+        characters".
         """
-        return claims['sub']
+        return urllib.parse.quote(claims['sub'], safe='').replace('%', '@')
 
     def create_user(self, claims):
         """

--- a/mentoring/auth.py
+++ b/mentoring/auth.py
@@ -35,8 +35,11 @@ class MentoringAuthBackend(OIDCAuthenticationBackend):
         user.email = claims.get('email', '')
         user.last_name = claims.get('family_name', '')
 
+        # assign is_staff and is_superuser to all STAFF_GROUPS; this gives
+        # access to all the things, including the admin console.
         groups = claims.get("https://sso.mozilla.com/claim/groups", [])
         user.is_staff = any(x in groups for x in settings.STAFF_GROUPS)
+        user.is_superuser = user.is_staff
 
         user.save()
 

--- a/mentoring/auth.py
+++ b/mentoring/auth.py
@@ -32,7 +32,7 @@ class MentoringAuthBackend(OIDCAuthenticationBackend):
         user.last_name = claims.get('family_name', '')
 
         groups = claims.get("https://sso.mozilla.com/claim/groups", [])
-        user.is_staff = any(x in groups for x in settings.ALLOWED_ADMIN_GROUPS)
+        user.is_staff = any(x in groups for x in settings.STAFF_GROUPS)
 
         user.save()
 

--- a/mentoring/frontend/templates/frontend/root.html
+++ b/mentoring/frontend/templates/frontend/root.html
@@ -12,7 +12,11 @@
 </body>
 {% csrf_token %}
 <script>
-const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
+const MENTORING_SETTINGS = {
+  csrftoken: document.querySelector('[name=csrfmiddlewaretoken]').value,
+  loginUrl: "{% url 'oidc_authentication_init' %}",
+  logoutUrl: "{% url 'oidc_logout' %}",
+};
 </script>
 {% load static %}
 <script src="{% static "frontend/main.js" %}"></script>

--- a/mentoring/frontend/templates/frontend/root.html
+++ b/mentoring/frontend/templates/frontend/root.html
@@ -21,8 +21,6 @@ const MENTORING_SETTINGS = {
     last_name: "{{ user.last_name }}",
     is_staff: "{{ user.is_staff }}" === "True",
   },
-  loginUrl: "{% url 'oidc_authentication_init' %}",
-  logoutUrl: "{% url 'oidc_logout' %}",
 };
 </script>
 {% load static %}

--- a/mentoring/frontend/templates/frontend/root.html
+++ b/mentoring/frontend/templates/frontend/root.html
@@ -14,6 +14,13 @@
 <script>
 const MENTORING_SETTINGS = {
   csrftoken: document.querySelector('[name=csrfmiddlewaretoken]').value,
+  user: {
+    username: "{{ user.username }}",
+    email: "{{ user.email }}",
+    first_name: "{{ user.first_name }}",
+    last_name: "{{ user.last_name }}",
+    is_staff: "{{ user.is_staff }}" === "True",
+  },
   loginUrl: "{% url 'oidc_authentication_init' %}",
   logoutUrl: "{% url 'oidc_logout' %}",
 };

--- a/mentoring/frontend/views.py
+++ b/mentoring/frontend/views.py
@@ -1,4 +1,8 @@
 from django.shortcuts import render
+from django.contrib.auth.decorators import user_passes_test
 
+# Check that a user is authenticated; this automatically redirects un-authenticated
+# users to the SSO login page (and right back if auto-login is enabled)
+@user_passes_test(lambda user: user.is_authenticated)
 def root(request):
     return render(request, 'frontend/root.html', {})

--- a/mentoring/pairing/rest.py
+++ b/mentoring/pairing/rest.py
@@ -19,6 +19,5 @@ class PairSerializer(serializers.HyperlinkedModelSerializer):
 
 # ViewSets define the view behavior.
 class PairViewSet(mixins.CreateModelMixin, viewsets.ReadOnlyModelViewSet):
-    permission_classes = [permissions.IsAuthenticated]
     queryset = Pair.objects.all()
     serializer_class = PairSerializer

--- a/mentoring/participants/rest.py
+++ b/mentoring/participants/rest.py
@@ -25,6 +25,5 @@ class ParticipantSerializer(serializers.HyperlinkedModelSerializer):
 
 # ViewSets define the view behavior.
 class ParticipantViewSet(viewsets.ReadOnlyModelViewSet):
-    permission_classes = [permissions.IsAuthenticated]
     queryset = Participant.objects.all()
     serializer_class = ParticipantSerializer

--- a/mentoring/settings.py
+++ b/mentoring/settings.py
@@ -138,9 +138,9 @@ LOGOUT_REDIRECT_URL = "/"
 # URL to which the user should be redirected in order to login
 LOGIN_URL = '/oidc/authenticate/'
 
-# Members of these Mozilla SSO groups will be Django admins, able to do everything;
+# Members of these Mozilla SSO groups will be Django staff, able to do everything;
 # this capability is given to committee members.
-ALLOWED_ADMIN_GROUPS = [
+STAFF_GROUPS = [
     'team_taskcluster',
 ]
 

--- a/mentoring/settings.py
+++ b/mentoring/settings.py
@@ -131,8 +131,12 @@ OIDC_OP_USER_ENDPOINT = "https://auth.mozilla.auth0.com/userinfo"
 OIDC_OP_AUTHORIZATION_ENDPOINT = "https://auth.mozilla.auth0.com/authorize"
 OIDC_RP_SCOPES = "openid email profile"
 
+# URLs to which the user will be redirected when login/logout are complete
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/"
+
+# URL to which the user should be redirected in order to login
+LOGIN_URL = '/oidc/authenticate/'
 
 # Members of these Mozilla SSO groups will be Django admins, able to do everything;
 # this capability is given to committee members.

--- a/mentoring/settings.py
+++ b/mentoring/settings.py
@@ -52,7 +52,6 @@ INSTALLED_APPS = [
     'django.contrib.auth',
     'mozilla_django_oidc',
     'django.contrib.contenttypes',
-    # TODO: disable with oidc?
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
@@ -61,7 +60,6 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
-    # TODO: disable with oidc?
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/mentoring/settings.py
+++ b/mentoring/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 
 from pathlib import Path
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -37,6 +38,9 @@ DATA_RETENTION_DAYS = 180
 # secret key for hashing pair_ids (treat like SECRET_KEY)
 PAIR_ID_HASH_SECRET = 'chod6oojiephahqu6ohseiN7uuj2ma'
 
+# Trust X-Forwarded-Proto to signify a secure connection
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
 # Application definition
 
 INSTALLED_APPS = [
@@ -46,7 +50,9 @@ INSTALLED_APPS = [
     'mentoring.frontend.apps.FrontendConfig',
     'django.contrib.admin',
     'django.contrib.auth',
+    'mozilla_django_oidc',
     'django.contrib.contenttypes',
+    # TODO: disable with oidc?
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
@@ -55,6 +61,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    # TODO: disable with oidc?
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -107,6 +114,24 @@ DATABASES = {
     }
 }
 
+# Authentication
+# https://mozilla-django-oidc.readthedocs.io/en/stable/installation.html
+
+AUTHENTICATION_BACKENDS = [
+    'mozilla_django_oidc.auth.OIDCAuthenticationBackend',
+]
+
+OIDC_RP_SIGN_ALGO = "RS256"
+OIDC_RP_CLIENT_ID = os.environ['OIDC_RP_CLIENT_ID']
+OIDC_RP_CLIENT_SECRET = os.environ['OIDC_RP_CLIENT_SECRET']
+# OIDC_OP_* come from https://auth.mozilla.auth0.com/.well-known/openid-configuration
+OIDC_OP_JWKS_ENDPOINT = "https://auth.mozilla.auth0.com/.well-known/jwks.json"
+OIDC_OP_TOKEN_ENDPOINT = "https://auth.mozilla.auth0.com/oauth/token"
+OIDC_OP_USER_ENDPOINT = "https://auth.mozilla.auth0.com/userinfo"
+OIDC_OP_AUTHORIZATION_ENDPOINT = "https://auth.mozilla.auth0.com/authorize"
+
+LOGIN_REDIRECT_URL = "/"
+LOGOUT_REDIRECT_URL = "/"
 
 # Password validation
 # https://docs.djangoproject.com/en/3.1/ref/settings/#auth-password-validators

--- a/mentoring/settings.py
+++ b/mentoring/settings.py
@@ -144,6 +144,13 @@ STAFF_GROUPS = [
     'team_taskcluster',
 ]
 
+# Default permission for all API methods is to require user.is_staff
+REST_FRAMEWORK = {
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.IsAdminUser',
+    ]
+}
+
 # Password validation
 # https://docs.djangoproject.com/en/3.1/ref/settings/#auth-password-validators
 

--- a/mentoring/settings.py
+++ b/mentoring/settings.py
@@ -118,7 +118,7 @@ DATABASES = {
 # https://mozilla-django-oidc.readthedocs.io/en/stable/installation.html
 
 AUTHENTICATION_BACKENDS = [
-    'mozilla_django_oidc.auth.OIDCAuthenticationBackend',
+    'mentoring.auth.MentoringAuthBackend',
 ]
 
 OIDC_RP_SIGN_ALGO = "RS256"
@@ -129,9 +129,16 @@ OIDC_OP_JWKS_ENDPOINT = "https://auth.mozilla.auth0.com/.well-known/jwks.json"
 OIDC_OP_TOKEN_ENDPOINT = "https://auth.mozilla.auth0.com/oauth/token"
 OIDC_OP_USER_ENDPOINT = "https://auth.mozilla.auth0.com/userinfo"
 OIDC_OP_AUTHORIZATION_ENDPOINT = "https://auth.mozilla.auth0.com/authorize"
+OIDC_RP_SCOPES = "openid email profile"
 
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/"
+
+# Members of these Mozilla SSO groups will be Django admins, able to do everything;
+# this capability is given to committee members.
+ALLOWED_ADMIN_GROUPS = [
+    'team_taskcluster',
+]
 
 # Password validation
 # https://docs.djangoproject.com/en/3.1/ref/settings/#auth-password-validators

--- a/mentoring/tests.py
+++ b/mentoring/tests.py
@@ -1,0 +1,19 @@
+import string
+
+from django.test import TestCase
+
+from .auth import MentoringAuthBackend
+
+class Auth(TestCase):
+
+    def get_username(self):
+        'Verify that get_username always generates valid Django usernames'
+        django_allowed = string.ascii_letters + string.digits + '_@+.-'
+        for oidc_username in string.printable:
+            username = MentoringAuthBackend().get_username({'sub': oidc_username})
+            if c in django_allowed:
+                self.assertEqual(username, oidc_username)
+            else:
+                self.assertNotEqual(username, oidc_username)
+            for c in oidc_username:
+                assert c in django_allowed

--- a/mentoring/urls.py
+++ b/mentoring/urls.py
@@ -10,6 +10,8 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     # the API
     path('api/', include(rest.router.urls)),
+    # oidc authentication
+    path('oidc/', include('mozilla_django_oidc.urls')),
     # ..and anything else renders the frontend
     path('', include('mentoring.frontend.urls')),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ djangorestframework==3.12.1
 pkg-resources==0.0.0
 pytz==2020.1
 sqlparse==0.4.1
+mozilla-django-oidc==1.2.4


### PR DESCRIPTION
The idea here is that:
 * anyone that's an employee can sign in (this is handled at the Auth0 configuration level)
 * anyone in ALLOWED_ADMIN_GROUPS is an admin and can make parings, edit the DB, etc.

TODO:
 * [x] automatically redirect to login when not logged in, so frontend is only rendered for logins
 * [x] protect API methods appropriately, requiring `is_staff`
 * [x] maybe don't use sessions?? https://mozilla-django-oidc.readthedocs.io/en/stable/installation.html#add-settings-to-settings-py *UPDATE:* I can't see what this warning is about, or what alternatives might exist
 * [x] handle the default 15-minute sign-out -- either extend this to 24h or something, or find a way to do a renewal without a page load (this is possible!) *UPDATE:* sessions last more than the 15 minutes that the access token does (maybe this is what the warning is about?), which is what we want.
 * [x] rename ALLOWED_ADMIN_GROUPS to IS_STAFF_GROUPS
 * [x] generate valid usernames

/cc @bowlofstew