### PR TITLE
add font-src/style-src 'self' for django admin views

### DIFF
--- a/mentoring/settings.py
+++ b/mentoring/settings.py
@@ -195,8 +195,8 @@ CSP_DEFAULT_SRC = ["'self'", "'unsafe-inline'"]
 # For development builds of the react app (`yarn dev`, not `yarn build`), eval is needed
 if DEBUG:
     CSP_DEFAULT_SRC.append("'unsafe-eval'")
-CSP_FONT_SRC = ["https://fonts.gstatic.com"]
-CSP_STYLE_SRC = ["'unsafe-inline'", "https://fonts.googleapis.com"]
+CSP_FONT_SRC = ["'self'", "https://fonts.gstatic.com"]
+CSP_STYLE_SRC = ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"]
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.1/howto/static-files/


### PR DESCRIPTION
These views use old-fashioned css and font URLs

Fixes #38.