### PR TITLE
AvailabilitySelector component

### DIFF
--- a/frontend/src/components/AvailabilitySelector.stories.js
+++ b/frontend/src/components/AvailabilitySelector.stories.js
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import propTypes from 'prop-types';
+import Card from '@material-ui/core/Card';
+
+import AvailabilitySelector from '../components/AvailabilitySelector';
+
+function Wrapper({ initialValue }) {
+  const [timeAvailability, setTimeAvailability] = useState(initialValue);
+  return (
+    <>
+      <Card style={{ padding: "1em" }}>
+        <AvailabilitySelector
+          timeAvailability={timeAvailability}
+          onChange={setTimeAvailability} />
+      </Card>
+      <Card>
+        Controlled value: <pre>{timeAvailability}</pre>
+      </Card>
+    </>
+  );
+}
+
+Wrapper.propTypes = {
+  initialValue: propTypes.string.isRequired,
+};
+
+export default {
+  title: 'Participants/AvailabilitySelector',
+};
+
+const Template = (args) => (
+  <Wrapper initialValue={args.initialValue} />
+);
+
+export const Empty = Template.bind({});
+Empty.args = {
+  initialValue: null
+};
+
+export const WorkingHours = Template.bind({});
+WorkingHours.args = {
+  initialValue: 'NNNNNNNNNYYYYYYYYNNNNNNN',
+};
+
+export const WrappedWorkingHours = Template.bind({});
+WrappedWorkingHours.args = {
+  initialValue: 'YYYYNNNNNNNNNNNNNNNNYYYY',
+};

--- a/frontend/src/components/AvailabilitySelector/CustomSelection.js
+++ b/frontend/src/components/AvailabilitySelector/CustomSelection.js
@@ -1,0 +1,55 @@
+import React from "react";
+import propTypes from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import Checkbox from '@material-ui/core/Checkbox';
+import Grid from '@material-ui/core/Grid';
+import { formatHour } from './util';
+
+const useStyles = makeStyles({
+  reallyDense: {
+    // Google's notion of "dense" gets sparser every year...
+    paddingTop: 0,
+    paddingBottom: 0,
+  },
+});
+
+export default function CustomSelection({ value, onChange }) {
+  const classes = useStyles();
+
+  const handleClick = h => {
+    const splitValue = value.split('');
+    splitValue[h] = splitValue[h] === 'Y' ? 'N' : 'Y';
+    onChange(splitValue.join(''));
+  };
+
+  return (
+    <Grid container justify="center">
+        {[0, 12].map(q => (
+          <Grid item key={q} xs={12} sm={6}>
+            <List dense>
+              {value.slice(q, q + 12).split('').map((v, qh) => (
+                <ListItem className={classes.reallyDense} key={qh} onClick={() => handleClick(q + qh)} >
+                  <ListItemIcon>
+                    <Checkbox
+                      edge="start"
+                      checked={v === 'Y'}
+                      inputProps={{ 'aria-labelledby': formatHour(q + qh) }} />
+                  </ListItemIcon>
+                  <ListItemText aria-label={formatHour(q + qh)} primary={formatHour(q + qh)} />
+                </ListItem>
+              ))}
+            </List>
+          </Grid>
+        ))}
+    </Grid>
+  );
+}
+
+CustomSelection.propTypes = {
+  value: propTypes.string.isRequired,
+  onChange: propTypes.func.isRequired,
+};

--- a/frontend/src/components/AvailabilitySelector/CustomSelection.js
+++ b/frontend/src/components/AvailabilitySelector/CustomSelection.js
@@ -27,7 +27,7 @@ export default function CustomSelection({ value, onChange }) {
   };
 
   return (
-    <Grid container justify="center">
+    <Grid data-testid="custom-selection" container justify="center">
         {[0, 12].map(q => (
           <Grid item key={q} xs={12} sm={6}>
             <List dense>

--- a/frontend/src/components/AvailabilitySelector/RangeSelection.js
+++ b/frontend/src/components/AvailabilitySelector/RangeSelection.js
@@ -1,0 +1,32 @@
+import React from "react";
+import propTypes from 'prop-types';
+import Slider from '@material-ui/core/Slider';
+import Hidden from '@material-ui/core/Hidden';
+import { formatHour } from './util';
+
+export default function RangeSelection({ range, onChange }) {
+  // use marks to label the current times, rather than the (much larger) value labels
+  const marks = [
+    { value: range[0], label: formatHour(range[0]) },
+    { value: range[1], label: formatHour(range[1]) },
+  ];
+  // only include noon, as a landmark, if it's not one of the endpoints
+  if (range[0] !== 12 && range[1] !== 12) {
+    marks.push({ value: 12, label: (<Hidden xsDown>{formatHour(12)}</Hidden>) });
+  }
+
+  return (
+    <Slider
+      min={0}
+      max={24}
+      marks={marks}
+      value={range}
+      valueLabelDisplay="off"
+      onChange={onChange} />
+  );
+}
+
+RangeSelection.propTypes = {
+  range: propTypes.arrayOf(propTypes.number).isRequired,
+  onChange: propTypes.func.isRequired,
+};

--- a/frontend/src/components/AvailabilitySelector/RangeSelection.js
+++ b/frontend/src/components/AvailabilitySelector/RangeSelection.js
@@ -17,6 +17,7 @@ export default function RangeSelection({ range, onChange }) {
 
   return (
     <Slider
+      data-testid="range-slider"
       min={0}
       max={24}
       marks={marks}

--- a/frontend/src/components/AvailabilitySelector/index.js
+++ b/frontend/src/components/AvailabilitySelector/index.js
@@ -1,0 +1,120 @@
+import React, { useState } from "react";
+import propTypes from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
+import Grid from '@material-ui/core/Grid';
+import Switch from '@material-ui/core/Switch';
+import Tooltip from '@material-ui/core/Tooltip';
+import Hidden from '@material-ui/core/Hidden';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Typography from '@material-ui/core/Typography';
+import CustomSelection from './CustomSelection';
+import RangeSelection from './RangeSelection';
+import { rangeToYN, ynToRange, utcToLocal, localToUtc } from './util';
+
+const useStyles = makeStyles(theme => {
+  // copied (roughly) from OutlinedInput
+  const borderColor = theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)';
+
+  return {
+    box: {
+			// copied (roughly) from OutlinedInput
+      borderRadius: theme.shape.borderRadius,
+      borderStyle: "solid",
+      borderWidth: 1,
+      borderColor,
+      padding: theme.spacing(1),
+    },
+		header: {
+			paddingLeft: theme.spacing(1),
+		},
+  };
+});
+
+// Allow the user to select their time_availability.  The timeAvailability
+// parameter is in the form of a 24-character string, containing `Y` or `N` in
+// each position, corresponding to the person's availability at that hour
+// offset from midnight, UTC.  So someone available from 3am-11am UTC would
+// have availability `NNNYYYYYYYYYNNNNNNNNNNNN`.  The control assumes that
+// most users will be available during a single block of time (working hours)
+// and uses a range slider for that condition, but allows the user to select
+// specific hours in a "custom" variant of the control.
+export default function AvailabilitySelector({ timeAvailability, onChange }) {
+  const classes = useStyles();
+
+  // if null or invalid, treat as 9-5 local time
+  if (timeAvailability === null || timeAvailability.length !== 24) {
+    timeAvailability = localToUtc('NNNNNNNNNYYYYYYYYNNNNNNN');
+    onChange(timeAvailability);
+  }
+
+  // translate the availability to local time by rotating the string
+  const localAvailability = utcToLocal(timeAvailability);
+
+  let range = ynToRange(localAvailability);
+
+  // track the custom switch's state, but for a non-range-compatible value, require
+  // the custom view.
+  const [custom, setCustom] = useState(!range);
+  const customRequired = !range;
+
+  const onRangeChange = (e, range) => {
+    const yn = rangeToYN(range);
+    if (yn) {
+      onChange(localToUtc(yn));
+    }
+  };
+
+  const onCustomChange = local => {
+    onChange(localToUtc(local));
+  };
+
+  return (
+    <Box className={classes.box}>
+      <Grid container justify="space-between">
+        <Grid item xs={9}>
+          <Typography className={classes.header} display="block" variant="body1">Time Availability</Typography>
+          <Typography className={classes.header} display="block" variant="caption" color="textSecondary">
+            Hours you are available to meet (in your timezone)
+          </Typography>
+        </Grid>
+        <Grid item xs={3} align="right">
+          <Tooltip title={"Custom time selection" + (customRequired ? " (required because times are not contiguous)" : "")}>
+            <FormControlLabel
+                control={(
+                  <Switch
+                    color="secondary"
+                    checked={custom || customRequired}
+                    disabled={customRequired}
+                    onChange={() => setCustom(!custom)}
+                    size="small" />
+                )}
+                labelPlacement="bottom"
+                label={(
+                  <Hidden xsDown>
+                    <Typography variant="caption">Custom</Typography>
+                  </Hidden>
+                )} />
+          </Tooltip>
+        </Grid>
+        <Grid item xs={12}>
+          {(custom || customRequired) ? (
+            <CustomSelection
+              value={localAvailability}
+              onChange={onCustomChange} />
+          ) : (
+            <RangeSelection
+              range={range}
+              onChange={onRangeChange} />
+          )}
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}
+
+AvailabilitySelector.propTypes = {
+  timeAvailability: propTypes.string,
+  onChange: propTypes.func.isRequired,
+};
+

--- a/frontend/src/components/AvailabilitySelector/util.js
+++ b/frontend/src/components/AvailabilitySelector/util.js
@@ -1,0 +1,45 @@
+// format a numeric hour as a 12-hour time
+export const formatHour = h => {
+  if (h === 0 || h === 24) {
+    return "12am";
+  }
+  if (h < 12) {
+    return `${h}am`;
+  }
+  if (h === 12) {
+    return `noon`;
+  }
+  return `${h-12}pm`;
+};
+
+// convert a range [min, max] to a YYNN string, or return null
+// if the range cannot be represented that way (min == max)
+export const rangeToYN = ([a, b]) => {
+  if (a === b) {
+    return null; // disallowed
+  }
+  return ('N'.repeat(a) + 'Y'.repeat(b-a)).padEnd(24, 'N');
+}
+
+// convert the given YYNN string into a range, if possible
+export const ynToRange = yn => {
+  const match = yn.match(/^(N*)(Y*)N*$/);
+  if (match) {
+    return [match[1].length, match[1].length + match[2].length];
+  }
+  return null;
+};
+
+const TZ_OFFSET_POSITIVE_HOURS = (Math.floor(new Date().getTimezoneOffset() / 60) + 24) % 24;
+
+// Convert a YYNN string from UTC to the user's local timezone.
+// This ignores any additional minutes on non-hour-offset timezones.
+// That's OK -- this control is just selecting time ranges.
+export const utcToLocal = utc => {
+  return utc.slice(TZ_OFFSET_POSITIVE_HOURS, 24) + utc.slice(0, TZ_OFFSET_POSITIVE_HOURS);
+};
+
+// The reverse
+export const localToUtc = utc => {
+  return utc.slice(24 - TZ_OFFSET_POSITIVE_HOURS, 24) + utc.slice(0, 24 - TZ_OFFSET_POSITIVE_HOURS);
+};

--- a/frontend/src/components/AvailabilitySelector/util.js
+++ b/frontend/src/components/AvailabilitySelector/util.js
@@ -23,14 +23,15 @@ export const rangeToYN = ([a, b]) => {
 
 // convert the given YYNN string into a range, if possible
 export const ynToRange = yn => {
-  const match = yn.match(/^(N*)(Y*)N*$/);
+  const match = yn.match(/^(N*)(Y+)N*$/);
   if (match) {
     return [match[1].length, match[1].length + match[2].length];
   }
   return null;
 };
 
-const TZ_OFFSET_POSITIVE_HOURS = (Math.floor(new Date().getTimezoneOffset() / 60) + 24) % 24;
+let TZ_OFFSET_POSITIVE_HOURS = (Math.floor(new Date().getTimezoneOffset() / 60) + 24) % 24;
+export const set_TZ_OFFSET_POSITIVE_HOURS = h => TZ_OFFSET_POSITIVE_HOURS = h;
 
 // Convert a YYNN string from UTC to the user's local timezone.
 // This ignores any additional minutes on non-hour-offset timezones.

--- a/frontend/src/components/AvailabilitySelector_test.js
+++ b/frontend/src/components/AvailabilitySelector_test.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import AvailabilitySelector from './AvailabilitySelector';
+import {
+  set_TZ_OFFSET_POSITIVE_HOURS,
+  utcToLocal,
+  localToUtc,
+  rangeToYN,
+  ynToRange,
+  formatHour,
+} from './AvailabilitySelector/util';
+
+describe('AvailabilitySelector', () => {
+  beforeEach(() => {
+    set_TZ_OFFSET_POSITIVE_HOURS(0);
+  });
+
+  describe('util', () => {
+    test('utcToLocal for UTC = local', () => {
+      expect(utcToLocal('NYYYNNNNNNNNNYYYNNNYYYNN')).toEqual('NYYYNNNNNNNNNYYYNNNYYYNN');
+    });
+
+    test('utcToLocal for east of meridan', () => {
+      set_TZ_OFFSET_POSITIVE_HOURS(22); // UTC+2:00, so things are later than in UTC
+      expect(utcToLocal('NYYYNNNNNNNNNYYYNNNYYYNN')).toEqual('NNNYYYNNNNNNNNNYYYNNNYYY');
+    });
+
+    test('utcToLocal for west of meridan', () => {
+      set_TZ_OFFSET_POSITIVE_HOURS(5); // UTC-5:00, so things are earlier than in UTC
+      expect(utcToLocal('NYYYNNNNNNNNNYYYNNNYYYNN')).toEqual('NNNNNNNNYYYNNNYYYNNNYYYN');
+    });
+
+    test('localToUtc for UTC = local', () => {
+      expect(localToUtc('NYYYNNNNNNNNNYYYNNNYYYNN')).toEqual('NYYYNNNNNNNNNYYYNNNYYYNN');
+    });
+
+    test('localToUtc for east of meridian', () => {
+      set_TZ_OFFSET_POSITIVE_HOURS(22); // UTC+2:00, so things are later than in UTC
+      expect(localToUtc('NYYYNNNNNNNNNYYYNNNYYYNN')).toEqual('YYNNNNNNNNNYYYNNNYYYNNNY');
+    });
+
+    test('localToUtc for west of meridian', () => {
+      set_TZ_OFFSET_POSITIVE_HOURS(5); // UTC-5:00, so things are earlier than in UTC
+      expect(localToUtc('NYYYNNNNNNNNNYYYNNNYYYNN')).toEqual('YYYNNNYYYNNNNNNNNNYYYNNN');
+    });
+
+    test('rangeToYN', () => {
+      expect(rangeToYN([3, 5])).toEqual('NNNYYNNNNNNNNNNNNNNNNNNN');
+      expect(rangeToYN([0, 23])).toEqual('YYYYYYYYYYYYYYYYYYYYYYYN');
+    });
+
+    test('ynToRange', () => {
+      expect(ynToRange('NNNNNNNNNNNNNNNNNNNNNNNN')).toEqual(null);
+      expect(ynToRange('NNYYYNNNNNNNYYYNNNNNNNNN')).toEqual(null);
+      expect(ynToRange('NYYYNNNNNNNNNNNNNNNNNNNN')).toEqual([1, 4]);
+      expect(ynToRange('YYYYYYYYYYYYYYYYYYYYYYYY')).toEqual([0, 24]);
+    });
+
+    test('formatHour', () => {
+      [
+        [0, '12am'],
+        [1, '1am'],
+        [2, '2am'],
+        [11, '11am'],
+        [12, 'noon'],
+        [13, '1pm'],
+        [14, '2pm'],
+        [23, '11pm'],
+      ].forEach(([h, str]) => expect(formatHour(h)).toEqual(str));
+    });
+  });
+
+  describe('component', () => {
+    test('shows slider with a contiguous time range', () => {
+      const handleChange = jest.fn();
+      const { getByTestId } = render(
+        <AvailabilitySelector timeAvailability="NNYYYYYYYYNNNNNNNNNNNNNN" onChange={handleChange} />);
+      expect(getByTestId('range-slider')).toBeInTheDocument();
+    });
+
+    test('shows custom view with a non-contiguous time range', () => {
+      const handleChange = jest.fn();
+      const { getByTestId } = render(
+        <AvailabilitySelector timeAvailability="NNYYYYYYYYNNNNNYYYYYYNNN" onChange={handleChange} />);
+      expect(getByTestId('custom-selection')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
A Material-style component to allow selecting times of day that a person is available, fixing #44.

![image](https://user-images.githubusercontent.com/28673/106208054-c4362600-6190-11eb-9499-94956ccb0533.png)

![image](https://user-images.githubusercontent.com/28673/106208082-cdbf8e00-6190-11eb-8b8b-1cfd9b532ff2.png)


@sarah-clements, this is still a draft, but I'd like to get your review. Specifically:
 * The "custom" switch hides its label at a small size, deferring to the tooltip.  But I think tooltips don't work on touch devices anyway, so this leaves users staring at an un-labeled control.  Ideas?
 * Similarly, the "custom" view is completely un-labeled, except for tooltips.  What would be a good, but small-screen-compatible, way to make this view usable?
 * I seem to be failing at flexbox in the custom view.  The image above shows 18 hours on one row and 6 on the next, and that's just really horrible.  I will keep futzing with that once I've got a plan for the previous point, but if you see an obvious fix I'm interested :)

Still to do:
 * offset back and forth from the user's timezone to UTC
 * include the name of the user's timezone, if available, in the caption