### PR TITLE
Get ready for production;

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,5 @@ RUN pip install -U pip && \
     python -m compileall ./mentoring/
 
 EXPOSE 8000
-ENV DJANGO_CONFIGURATION=Production
 
 CMD /app/run-prod.sh

--- a/mentoring/settings.py
+++ b/mentoring/settings.py
@@ -140,7 +140,6 @@ class Production(Base):
 
     # security settings
     SECURE_HSTS_SECONDS = 3600
-    SECURE_SSL_REDIRECT = True
     SECURE_REFERRER_POLICY = 'same-origin'
     SECURE_CONTENT_TYPE_NOSNIFF = True
     SESSION_COOKIE_SECURE = 1  # Set that the cookie should only be sent on https

--- a/mentoring/wsgi.py
+++ b/mentoring/wsgi.py
@@ -1,8 +1,3 @@
-import os
-
 from configurations.wsgi import get_wsgi_application
-
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'mentoring.settings')
-os.environ.setdefault('DJANGO_CONFIGURATION', 'Production')
 
 application = get_wsgi_application()

--- a/run-prod.sh
+++ b/run-prod.sh
@@ -1,4 +1,6 @@
 #!/bin/sh -xe
 
+export DJANGO_SETTINGS_MODULE="mentoring.settings"
+
 python manage.py migrate
-gunicorn mentoring.wsgi:application -b 0.0.0.0:${PORT:-8000} --log-file -
+gunicorn mentoring.wsgi:application -b 0.0.0.0:"${PORT:-8000}" --log-file -

--- a/run-prod.sh
+++ b/run-prod.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -xe
 
 export DJANGO_SETTINGS_MODULE="mentoring.settings"
+export DJANGO_CONFIGURATION="Production"
 
 python manage.py migrate
 gunicorn mentoring.wsgi:application -b 0.0.0.0:"${PORT:-8000}" --log-file -


### PR DESCRIPTION
 * export DJANGO_SETTINGS_MODULE to fix "django.core.exceptions.ImproperlyConfigured: Configuration cannot be imported, environment variable DJANGO_SETTINGS_MODULE is undefined."
 * Do not force SSL Redirection in the app. This is going to be done at the loadbalancer level, which terminates SSL traffic. Enforcing this setting in the app layer makes it not possible to test the deployment in "Production" mode without creating fake certs.