### PR TITLE
CI job for building and pushing Docker containers

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,36 @@
+name: Publish Docker image
+on:
+  release:
+    types: [published]
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: Login to ECR
+        uses: docker/login-action@v1
+        with:
+          registry: 783633885093.dkr.ecr.us-west-2.amazonaws.com
+      - name: docker-tags
+        id: tags
+        run: |
+          DOCKER_IMAGE=783633885093.dkr.ecr.us-west-2.amazonaws.com/mentoring
+          VERSION=latest
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          fi
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          echo ::set-output name=tags::${TAGS}
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}

--- a/README.md
+++ b/README.md
@@ -61,3 +61,9 @@ Members of People API groups listed in `DJANGO_STAFF_GROUPS` (comma-separated) h
 This grants access to the REST API (`/api`) and the Django administration panel (`/admin/`).
 This should be set to a group containing the Mentoring committee members, e.g., `mozilliansorg_mentoring-committee`.
 Those who are not staff have access only to the enrollment form.
+
+# Deploy to Production
+Deploying to production can be done by creating a new "Release" in GitHub from [here](https://github.com/mozilla/mentoring/releases) and tagging it with a semversion tag, for example `0.1.2`.
+
+Behind the scenes the new Release will trigger [this](https://github.com/mozilla/mentoring/tree/main/.github/workflows/docker.yaml) Github CI job. The job builds and pushes a Docker container based on [this Dockerfile]((https://github.com/mozilla/mentoring/tree/main/Dockerfile) into a private ECR repo.
+Running alongside this application there's a service watching the ECR repository, and deploying any new container tagged with a semversion.


### PR DESCRIPTION
This PR will enable a Github action for building and pushing a container into ECR.

It expects to have 2 secrets which have to be added in Settings -> Secrets.
Dustin, I'll be sending you those by a secure channel.