### PR TITLE
Use distinct SSO groups for staff / superuser

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,16 @@ There is no way to interact with the UI without first signing in.
 Signing in creates a Django user and remaining authentication is performed using a Django session.
 
 Members of People API groups listed in `DJANGO_STAFF_GROUPS` (comma-separated) have "staff" access to the app.
-This grants access to the REST API (`/api`) and the Django administration panel (`/admin/`).
+This grants access to the REST API (`/api`) for pairing and other committee- activities.
 This should be set to a group containing the Mentoring committee members, e.g., `mozilliansorg_mentoring-committee`.
-Those who are not staff have access only to the enrollment form.
+
+The `DJANGO_ADMIN_GROUPS` setting controls admin access, which includes staff permissions as well as access to the Django administration panel (`/admin/`).
+This should be given to the subset of the committee that might need to make ad-hoc modifications to the database, and be capable of doing so safely
+
+Those who are not staff or admins have access only to the enrollment form.
 
 # Deploy to Production
+
 Deploying to production can be done by creating a new "Release" in GitHub from [here](https://github.com/mozilla/mentoring/releases) and tagging it with a semversion tag, for example `0.1.2`.
 
 Behind the scenes the new Release will trigger [this](https://github.com/mozilla/mentoring/tree/main/.github/workflows/docker.yaml) Github CI job. The job builds and pushes a Docker container based on [this Dockerfile](https://github.com/mozilla/mentoring/tree/main/Dockerfile) into a private ECR repo.

--- a/mentoring/auth.py
+++ b/mentoring/auth.py
@@ -38,8 +38,8 @@ class MentoringAuthBackend(OIDCAuthenticationBackend):
         # assign is_staff and is_superuser to all STAFF_GROUPS; this gives
         # access to all the things, including the admin console.
         groups = claims.get("https://sso.mozilla.com/claim/groups", [])
-        user.is_staff = any(x in groups for x in settings.STAFF_GROUPS)
-        user.is_superuser = user.is_staff
+        user.is_superuser = any(x in groups for x in settings.ADMIN_GROUPS)
+        user.is_staff = user.is_superuser or any(x in groups for x in settings.STAFF_GROUPS)
 
         user.save()
 

--- a/mentoring/settings.py
+++ b/mentoring/settings.py
@@ -132,9 +132,14 @@ class Production(Base):
     OIDC_AUTHENTICATION_CALLBACK_URL = values.Value(environ_required=True)
     OIDC_RP_SCOPES = "openid email profile"
 
-    # Members of these Mozilla SSO groups will be Django staff, able to do everything;
+    # Members of these Mozilla SSO groups will be Django staff, able to perform pairing;
     # this capability is given to committee members.
     STAFF_GROUPS = values.ListValue(environ_required=True)
+
+    # Members of these Mozilla SSO groups will be Django superusers, able to do
+    # everything; this capability should be given to a subset of committee
+    # members who can use the power safely
+    ADMIN_GROUPS = values.ListValue(environ_required=True)
 
     # determine the database configuration from DATABASE_URL
     DATABASES = values.DatabaseURLValue()


### PR DESCRIPTION
This separates the DB admin access from the general staff (=committee)
access.