### PR TITLE
Remove 'unsafe' bits from CSP.

### DIFF
--- a/mentoring/frontend/templates/frontend/root.html
+++ b/mentoring/frontend/templates/frontend/root.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
   <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
+  <meta property="csp-nonce" content="{{ request.csp_nonce }}">
 </head>
 <body>
 <div id="app">

--- a/mentoring/frontend/templates/frontend/root.html
+++ b/mentoring/frontend/templates/frontend/root.html
@@ -10,19 +10,7 @@
     <!-- React will load here -->
 </div>
 </body>
-{% csrf_token %}
-<script>
-const MENTORING_SETTINGS = {
-  csrftoken: document.querySelector('[name=csrfmiddlewaretoken]').value,
-  user: {
-    username: "{{ user.username }}",
-    email: "{{ user.email }}",
-    first_name: "{{ user.first_name }}",
-    last_name: "{{ user.last_name }}",
-    is_staff: "{{ user.is_staff }}" === "True",
-  },
-};
-</script>
+<script src="/settings.js"></script>
 {% load static %}
 <script src="{% static "frontend/main.js" %}"></script>
 </html>

--- a/mentoring/frontend/urls.py
+++ b/mentoring/frontend/urls.py
@@ -1,8 +1,9 @@
-from django.urls import re_path
+from django.urls import re_path, path
 
 from . import views
 
 urlpatterns = [
+    path('settings.js', views.settings),
     # render the same view for any URL; the react router sorts it out
     re_path('.*', views.root, name='root'),
 ]

--- a/mentoring/frontend/views.py
+++ b/mentoring/frontend/views.py
@@ -1,4 +1,6 @@
+import json
 from django.shortcuts import render
+from django.http import HttpResponse
 from django.contrib.auth.decorators import user_passes_test
 
 
@@ -7,3 +9,24 @@ from django.contrib.auth.decorators import user_passes_test
 @user_passes_test(lambda user: user.is_authenticated)
 def root(request):
     return render(request, 'frontend/root.html', {})
+
+
+# Pass some settings off to the browser for use in the UI
+@user_passes_test(lambda user: user.is_authenticated)
+def settings(request):
+    user = request.user
+    settings = {
+        "csrftoken": "uhh",  # TODO: get from cookie - https://docs.djangoproject.com/en/3.1/ref/csrf/
+        "user": {
+            "username": user.username,
+            "email": user.email,
+            "first_name": user.first_name,
+            "last_name": user.last_name,
+            "is_staff": user.is_staff,
+        },
+    }
+    resp = HttpResponse(
+        f'const MENTORING_SETTINGS = {json.dumps(settings, indent=4)};',
+        content_type='application/javascript')
+    resp['Content-Disposition'] = 'inline; filename="settings.js"'
+    return resp

--- a/mentoring/frontend/views.py
+++ b/mentoring/frontend/views.py
@@ -2,6 +2,7 @@ import json
 from django.shortcuts import render
 from django.http import HttpResponse
 from django.contrib.auth.decorators import user_passes_test
+from django.middleware.csrf import get_token
 
 
 # Check that a user is authenticated; this automatically redirects un-authenticated
@@ -16,7 +17,7 @@ def root(request):
 def settings(request):
     user = request.user
     settings = {
-        "csrftoken": "uhh",  # TODO: get from cookie - https://docs.djangoproject.com/en/3.1/ref/csrf/
+        "csrftoken": get_token(request),
         "user": {
             "username": user.username,
             "email": user.email,

--- a/mentoring/settings.py
+++ b/mentoring/settings.py
@@ -87,8 +87,7 @@ class Base(Configuration):
     USE_TZ = True
 
     # content security policy
-    CSP_DEFAULT_SRC = ["'self'", "'unsafe-inline'"]
-    # For development builds of the react app (`yarn dev`, not `yarn build`), eval is needed
+    CSP_DEFAULT_SRC = ["'self'"]
     CSP_FONT_SRC = ["'self'", "https://fonts.gstatic.com"]
     CSP_STYLE_SRC = ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"]
 

--- a/mentoring/settings.py
+++ b/mentoring/settings.py
@@ -89,7 +89,8 @@ class Base(Configuration):
     # content security policy
     CSP_DEFAULT_SRC = ["'self'"]
     CSP_FONT_SRC = ["'self'", "https://fonts.gstatic.com"]
-    CSP_STYLE_SRC = ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"]
+    CSP_STYLE_SRC = ["'self'", "https://fonts.googleapis.com"]
+    CSP_INCLUDE_NONCE_IN = ['style-src']
 
     # Static files (CSS, JavaScript, Images)
     # https://docs.djangoproject.com/en/3.1/howto/static-files/


### PR DESCRIPTION
Fixes #93.

This leaves the unsafe-eval in development mode, but not in production.

I lost a bunch of time on this because the privacy-badger and react-dev-tools addons were triggering script-src warnings in the console that had nothing to do with my app.  Ugh :(