### PR TITLE
Revert use of OIDC_AUTHENTICATION_CALLBACK_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ It requires an Auth0 client be created, with
  * At least the Mozilla AD connection enabled ("Allowing Mozilla LDAP with MFA")
 
 Set `DJANGO_OIDC_RP_CLIENT_ID` `DJANGO_OIDC_RP_CLIENT_SECRET` using the resulting credentials.
-Set `DJANGO_OIDC_AUTHENTICATION_CALLBACK_URL` to `https://<hostname>/oidc/callback` where `<hostname>` is the hostname on which the site appears.
 
 The UI automatically redirects to the sign-in URL.
 There is no way to interact with the UI without first signing in.

--- a/mentoring/settings.py
+++ b/mentoring/settings.py
@@ -129,7 +129,6 @@ class Production(Base):
     OIDC_OP_TOKEN_ENDPOINT = "https://auth.mozilla.auth0.com/oauth/token"
     OIDC_OP_USER_ENDPOINT = "https://auth.mozilla.auth0.com/userinfo"
     OIDC_OP_AUTHORIZATION_ENDPOINT = "https://auth.mozilla.auth0.com/authorize"
-    OIDC_AUTHENTICATION_CALLBACK_URL = values.Value(environ_required=True)
     OIDC_RP_SCOPES = "openid email profile"
 
     # Members of these Mozilla SSO groups will be Django staff, able to do everything;


### PR DESCRIPTION
It turns out this parameter wants a reversible url pattern, which means that it will generate a URL with http or https based on `is_secure()`, which was the problem we were trying to solve.  And it seems we need to solve that directly.  It looks like this is a bug in the nginx ingress, fixed by https://github.com/kubernetes/ingress-nginx/pull/5042.