### PR TITLE
Ensure that all api/ paths always return JSON

### DIFF
--- a/mentoring/settings.py
+++ b/mentoring/settings.py
@@ -154,6 +154,14 @@ class Production(Base):
     SESSION_COOKIE_SECURE = 1  # Set that the cookie should only be sent on https
     CSRF_COOKIE_SECURE = 1  # Same for CSRF cookies
 
+    REST_FRAMEWORK = {
+        **Base.REST_FRAMEWORK,
+        'DEFAULT_RENDERER_CLASSES': (
+            # only render the JSON views in production
+            'rest_framework.renderers.JSONRenderer',
+        )
+    }
+
 
 class Development(Base):
     DEBUG = True

--- a/mentoring/urls.py
+++ b/mentoring/urls.py
@@ -1,6 +1,10 @@
+import json
+
 from django.conf import settings
 from django.contrib import admin
-from django.urls import include, path
+from django.urls import include, path, re_path
+from django.http import HttpResponse
+import django.views.defaults
 
 from . import rest
 
@@ -16,6 +20,37 @@ urlpatterns = [
     # users to sign in using simple Django auth
 ] + ([path('accounts/', include('django.contrib.auth.urls'))] if settings.DEBUG else []) + [
 
-    # ..and anything else renders the frontend
-    path('', include('mentoring.frontend.urls')),
+    # ..and anything else (that is not api/..) renders the frontend
+    re_path('^(?!api/)', include('mentoring.frontend.urls')),
 ]
+
+# ERROR HANDLING
+#
+# The below defines the special Django views handlerXXX so return a
+# JSON-formatted error under `/api`, but fall back to the normal views in other
+# cases.  Note that these views are not rendered in development mode
+# (DEBUG=True).  Note, also, that the signature of handler500 is different from
+# others, lacking the `exception` property.
+
+
+def define_error_handler(detail, status_code, original, nargs=2):
+    def handler(request, exception):
+        if not request.path_info.startswith('/api'):
+            if nargs == 1:
+                return original(request)
+            return original(request, exception)
+        response = HttpResponse(
+            json.dumps({"detail": detail}),
+            content_type="application/json")
+        response.status_code = status_code
+        return response
+
+    if nargs == 1:
+        return lambda request: handler(request, None)
+    return handler
+
+
+handler400 = define_error_handler("Bad request.", 400, django.views.defaults.bad_request)
+handler403 = define_error_handler("Permission denied.", 403, django.views.defaults.permission_denied)
+handler404 = define_error_handler("Not found.", 404, django.views.defaults.page_not_found)
+handler500 = define_error_handler("Internal server error.", 500, django.views.defaults.server_error, nargs=1)


### PR DESCRIPTION
Fixes #94.  Django's error-handling is global to the app, so we cannot use the normal routing behavior to customize error messages; instead, we just use `startswith` to disambiguate.